### PR TITLE
Fix file-accept-pred when not using promises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-component-form "0.2.14-SNAPSHOT"
+(defproject district0x/district-ui-component-form "0.2.15-SNAPSHOT"
   :description "district UI forms library "
   :url "https://github.com/district0x/district-ui-component-form"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
In the file-input component, you are able to specify the param "file-accept-pred" to evaluate if a file is accepted. This allows specify a function which return either a Promise or a (boolean) value. However, when returning a false or nil value, the file was always resolved as accepted. This PR fixed that.

Additionally, it has been added the "accept" parameter to apply a filter to the selection of files. For example, if only images are accepted.